### PR TITLE
adding more info to the product detail page.

### DIFF
--- a/buyusaapp/static/css/style.css
+++ b/buyusaapp/static/css/style.css
@@ -3336,12 +3336,6 @@ div.spec
     margin-bottom: 20px;
 }
 
-.gig_info{
-    line-height: 20px;
-    font-style: italic;    
-}
-
-
 /*** PROFILE ***/
 .profile{
     margin-top: 60px;
@@ -3479,3 +3473,28 @@ div.edit_gig div.form-group div#cke_id_description{
     margin-bottom: 10px;
     font-weight: bold;
 }
+
+/*** Extra Product Details ***/
+.details_brand p{
+    margin-top: 5px;    
+}
+
+.details_brand img{
+    margin-top: 5px;    
+}
+
+.gig_brand_cat{
+    float: right;
+}
+
+.gig_brand_cat h4{    
+    margin-top: 5px;
+}
+
+.gig_desc{    
+    padding-top: 20px;
+    padding-bottom: 20px;
+    border-bottom: 1px solid #eee;
+    clear: both;
+}
+

--- a/buyusaapp/templates/gig_detail.html
+++ b/buyusaapp/templates/gig_detail.html
@@ -37,12 +37,21 @@
         
         <div class="col-md-7 single-top-left ">
             <div class="single-right">
-                <h3>{{ gig.title }}</h3>    
-                <p class="gig_info">{{ gig.BrandCaption1 }} <br />{{ gig.category }}<br />
-                <i class="fa fa-phone" aria-hidden="true"></i>&nbsp;&nbsp;{{ gig.BrandCustomerServicePhone }}                
-                <p class="in-pa">{{ gig.description|safe }}</p>
+                <h3>{{ gig.title }}</h3>
+                <div class="gig_brand_cat">
+                    <img src="{% if gig.user.profile %} {{ gig.user.profile.avatar }} {% else %} {% static 'img/avatar.png' %} {% endif %}" class="img-circle center-block" height="70" width="70">
+                    <a href="{% url 'profile' gig.user.username %}"><h4 class="text-center">{{ gig.user.username }}</h4></a>
+                </div>
+                <div class="details_brand">
+                    <p>{{ gig.BrandCaption1 }}</p>
+                    <img src="{{ MEDIA_URL }}{{ gig.BrandLogo }}" class="img-responsive" width="120px" height="120px">
+                    <p><i class="fa fa-globe" aria-hidden="true"></i>&nbsp;&nbsp;<a href="https://{{ gig.BrandLink }}" target="_blank">{{ gig.BrandLink }}</a></p>
+                    <p><i class="fa fa-phone" aria-hidden="true"></i>&nbsp;&nbsp;{{ gig.BrandCustomerServicePhone }}</p>
+                </div>
+                <div class="gig_desc">
+                    <span class="gig_desc_text">{{ gig.description|safe }}</span>
+                </div>
                 <p class="where_to_buy">{{ gig.BrandWhereToBuy|commaSplit|safe }}</p>
-
                 <div class="clearfix"> </div>
             </div>
         </div>


### PR DESCRIPTION
can you see if you can address that first issue? when I view a product, I should also see somewhere relatively prominent some info about the parent company (in our case the website customer (not visitor but registered user/vendor)... perhaps the name of the company and a link to their site profile. 

before your changes... the product was about 2/3 or more of the page... and on the right was the parent vendor company name and link to profile